### PR TITLE
Update the Monarch installation scripts to handle previous installs properly

### DIFF
--- a/scripts/docker-install-monarch.sh
+++ b/scripts/docker-install-monarch.sh
@@ -5,10 +5,10 @@ set -e
 
 MONARCH_NET=monarch-net
 MONARCH_PATH=${HOME}/.monarch
-
-if [ -d "${MONARCH_PATH}" ]
+NET_EXISTS=$(docker network ls --filter name=^${MONARCH_NET}$ --format="{{ .Name }}")
+if [ -d "${MONARCH_PATH}" ] || [ "$NET_EXISTS" ]
 then
-  read -p "monarch folder exists. do you wish to reinstall? (y/N) " yn
+  read -p "monarch data exists. do you wish to reinstall? (y/N) " yn
   if [ "$yn" != "y" ] && [ "$yn" != "Y" ]; then
     exit 0
   fi
@@ -22,7 +22,13 @@ then
     docker container stop "$ACTIVE_CONTAINERS"
     docker container rm "$ACTIVE_CONTAINERS"
   fi
-  docker network rm "${MONARCH_NET}"
+  if [ "$(docker ps -qa -f name=monarch-ctr)" ]; then
+  	docker container rm monarch-ctr
+  fi
+  if [ "$NET_EXISTS" ]
+  then
+    docker network rm "${MONARCH_NET}"
+  fi
 else
   mkdir "${MONARCH_PATH}"
 fi

--- a/scripts/install-monarch.sh
+++ b/scripts/install-monarch.sh
@@ -7,10 +7,10 @@ cd "$(dirname "$0")"
 MONARCH_NAME="monarch"
 MONARCH_NET=monarch-net
 MONARCH_PATH=${HOME}/.monarch
-
-if [ -d "${MONARCH_PATH}" ]
+NET_EXISTS=$(docker network ls --filter name=^${MONARCH_NET}$ --format="{{ .Name }}")
+if [ -d "${MONARCH_PATH}" ] || [ "$NET_EXISTS" ]
 then
-  read -p "monarch folder exists. do you wish to reinstall? (y/N) " yn
+  read -p "monarch data exists. do you wish to reinstall? (y/N) " yn
   if [ "$yn" != "y" ] && [ "$yn" != "Y" ]; then
     exit 0
   fi
@@ -24,7 +24,13 @@ then
     docker container stop "$ACTIVE_CONTAINERS"
     docker container rm "$ACTIVE_CONTAINERS"
   fi
-  docker network rm "${MONARCH_NET}"
+  if [ "$(docker ps -qa -f name=monarch-ctr)" ]; then
+    docker container rm monarch-ctr
+  fi
+  if [ "$NET_EXISTS" ]
+  then
+    docker network rm "${MONARCH_NET}"
+  fi
 else
   mkdir "${MONARCH_PATH}"
 fi


### PR DESCRIPTION
# Changes
- Update the Monarch installation scripts to handle previous installs properly
- Check for existence of network before removing it
- Remove previous `Monarch-over-Docker` instances