### PR TITLE
Malleable HTTP Endpoints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,16 @@ on:
     branches:
       - main
 jobs:
+  build-all-monarch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+      - name: Build all Monarch clients
+        run: make linux macos windows
+
   build-test-monarch:
     runs-on: ubuntu-latest
     strategy:

--- a/configs/monarch.yaml
+++ b/configs/monarch.yaml
@@ -13,9 +13,8 @@ httpsport: 4433
 multiplayerport: 1337
 tcpport: 8888
 
-loginendpoint: /login # default endpoint for registering agents
-mainendpoint: / # default endpoint for interacting with agents
-stageendpoint: /index/{file} # default endpoint for staging agents (secondary payload)
+# configuration for HTTP(S) c2 endpoints
+httpconfig: monarch_http.json
 
 session_timeout_minutes: 60 # time until re-registration
 

--- a/configs/monarch_http.json
+++ b/configs/monarch_http.json
@@ -1,0 +1,51 @@
+{
+  "login_endpoint": {
+    "paths": [
+      {
+        "path": "/login",
+        "methods": [
+          "POST"
+        ]
+      }
+    ],
+    "headers": {
+      "content-type": "text/html; charset=UTF-8",
+      "cache-control": "max-age=0, no-cache, no-store"
+    }
+  },
+  "stage_endpoint": {
+    "paths": [
+      {
+        "path": "/index/{file}",
+        "methods": [
+          "GET"
+        ]
+      },
+      {
+        "path": "/{file}",
+        "methods": [
+          "GET"
+        ]
+      }
+    ],
+    "headers": {
+      "content-type": "text/html; charset=UTF-8",
+      "cache-control": "max-age=0, no-cache, no-store"
+    }
+  },
+  "main_endpoint": {
+    "paths": [
+      {
+        "path": "/",
+        "methods": [
+          "GET",
+          "POST"
+        ]
+      }
+    ],
+    "headers": {
+      "content-type": "text/html; charset=UTF-8",
+      "cache-control": "max-age=0, no-cache, no-store"
+    }
+  }
+}

--- a/pkg/commands/agents.go
+++ b/pkg/commands/agents.go
@@ -7,8 +7,8 @@ import (
 )
 
 // agentsCmd lists compiled agents
-func agentsCmd(names []string) {
-	agents, err := console.Rpc.Agents(ctx, &clientpb.AgentRequest{AgentId: names})
+func agentsCmd() {
+	agents, err := console.Rpc.Agents(ctx, &clientpb.AgentRequest{})
 	if err != nil {
 		cLogger.Error("failed to get agents: %v", err)
 		return

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -157,15 +157,9 @@ func ConsoleCommands() []*grumble.Command {
 		Name:      "agents",
 		Help:      "list compiled agents",
 		HelpGroup: consts.GeneralHelpGroup,
-		Args: func(a *grumble.Args) {
-			a.StringList("agents", "list of compiled agents")
-		},
 		Run: func(c *grumble.Context) error {
-			agentsCmd(c.Args.StringList("agents"))
+			agentsCmd()
 			return nil
-		},
-		Completer: func(prefix string, args []string) []string {
-			return completion.Agents(prefix, ctx)
 		},
 	}
 
@@ -337,8 +331,13 @@ func ConsoleCommands() []*grumble.Command {
 
 	cmdStage := &grumble.Command{
 		Name:      "stage",
-		Help:      "stage an agent on the configured staging endpoint, or view currently staged agents",
+		Help:      "use to manage agents on the configured stage listener(s)",
 		HelpGroup: consts.GeneralHelpGroup,
+	}
+
+	cmdStage.AddCommand(&grumble.Command{
+		Name: "add",
+		Help: "stage an existing agent",
 		Args: func(a *grumble.Args) {
 			a.String("agent", "the name of the agent to stage", grumble.Default(""))
 		},
@@ -346,17 +345,26 @@ func ConsoleCommands() []*grumble.Command {
 			f.StringL("as", "", "the file to stage your agent as (e.g. index.php)")
 		},
 		Run: func(c *grumble.Context) error {
-			stageCmd(c.Args.String("agent"), c.Flags.String("as"))
+			stageAddCmd(c.Args.String("agent"), c.Flags.String("as"))
 			return nil
 		},
 		Completer: func(prefix string, args []string) []string {
 			return completion.Agents(prefix, ctx)
 		},
-	}
+	})
+
+	cmdStage.AddCommand(&grumble.Command{
+		Name: "view",
+		Help: "view all currently staged agents",
+		Run: func(c *grumble.Context) error {
+			stageViewCmd()
+			return nil
+		},
+	})
 
 	cmdStage.AddCommand(&grumble.Command{
 		Name: "local",
-		Help: "stage a file on disk on an endpoint",
+		Help: "stage a file on disk",
 		Args: func(a *grumble.Args) {
 			a.String("file", "name of file to stage")
 		},
@@ -372,8 +380,8 @@ func ConsoleCommands() []*grumble.Command {
 		},
 	})
 
-	cmdUnstage := &grumble.Command{
-		Name:      "unstage",
+	cmdStage.AddCommand(&grumble.Command{
+		Name:      "rm",
 		Help:      "unstage a staged agent, by specifying its stage alias (e.g. index.php)",
 		HelpGroup: consts.GeneralHelpGroup,
 		Args: func(a *grumble.Args) {
@@ -386,7 +394,7 @@ func ConsoleCommands() []*grumble.Command {
 		Completer: func(prefix string, args []string) []string {
 			return completion.UnStage(prefix, ctx)
 		},
-	}
+	})
 
 	cmdPlayers = &grumble.Command{
 		Name: "players",
@@ -422,7 +430,7 @@ func ConsoleCommands() []*grumble.Command {
 	}
 
 	root = append(root, cmdSessions, cmdUse, cmdHttp, cmdHttps, cmdTcp,
-		cmdAgents, cmdBuilders, cmdBuild, cmdInstall, cmdUninstall, cmdStage, cmdUnstage, cmdVersion, cmdPlayers, cmdSend)
+		cmdAgents, cmdBuilders, cmdBuild, cmdInstall, cmdUninstall, cmdStage, cmdVersion, cmdPlayers, cmdSend)
 	return root
 }
 

--- a/pkg/commands/send.go
+++ b/pkg/commands/send.go
@@ -8,7 +8,7 @@ import (
 func sendCmd(to, msg string, all bool) {
 	if len(to) == 0 {
 		if !all {
-			cLogger.Error("player not specified with -to, please specify a player name or --all")
+			cLogger.Error("player not specified with --to, please specify a player name or --all if admin")
 			return
 		}
 	}

--- a/pkg/commands/stage.go
+++ b/pkg/commands/stage.go
@@ -10,25 +10,27 @@ import (
 	"strings"
 )
 
-func stageCmd(agent string, as string) {
-	if len(agent) == 0 {
-		s, err := console.Rpc.StageView(ctx, &clientpb.Empty{})
-		if err != nil {
-			cLogger.Error("%v", err)
-			return
-		}
-		stagefmt := "%s (%s)\tstaged as %s\t"
-		if len(s.Stage) == 0 {
-			cLogger.Info("nothing staged")
-			return
-		}
-		for k, v := range s.Stage {
-			_, _ = fmt.Fprintln(w, fmt.Sprintf(stagefmt, v.Path, v.Agent,
-				strings.ReplaceAll(s.Endpoint, "{file}", k)))
-		}
-		w.Flush()
+func stageViewCmd() {
+	s, err := console.Rpc.StageView(ctx, &clientpb.Empty{})
+	if err != nil {
+		cLogger.Error("%v", err)
 		return
 	}
+	stagefmt := "%s (%s)\tstaged as \n%s\t"
+	if len(s.Stage) == 0 {
+		cLogger.Info("nothing staged")
+		return
+	}
+	fmt.Printf("\n=====\n")
+	for k, v := range s.Stage {
+		_, _ = fmt.Fprintln(w, fmt.Sprintf(stagefmt, v.Path, v.Agent,
+			strings.ReplaceAll(s.Endpoint, "{file}", k)))
+	}
+	w.Flush()
+	fmt.Printf("=====\n\n")
+}
+
+func stageAddCmd(agent string, as string) {
 	notif, err := console.Rpc.StageAdd(ctx, &clientpb.StageAddRequest{Agent: agent, Alias: as})
 	if err != nil {
 		cLogger.Error("%v", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,105 +15,11 @@ import (
 var (
 	MainConfig        MonarchConfig
 	ClientConfig      MonarchClientConfig
+	C2Config          = newC2Config()
 	MonarchConfigFile string
 )
 
-// MonarchConfig is only used by monarch itself, not clients
-type MonarchConfig struct {
-	// Set monarch logging level, which can be one of: debug (1), informational (2), warning (3), fatal (4)
-	LogLevel uint16
-	// Path to the certificate file used for TLS enabled connections.
-	CertFile string
-	// Path to the key file used for TLS enabled connections.
-	KeyFile string
-	// certificate authority x509 key pair
-	CaCert string
-	CaKey  string
-	// The main interface that Monarch will bind to for operations.
-	Interface string
-	// The port to use for the Monarch HTTP listener.
-	HttpPort int
-	// The port to use for the Monarch HTTPS listener.
-	HttpsPort int
-	// RPC port for multiplayer
-	MultiplayerPort int
-	// Port to use for the Monarch TCP listener.
-	TcpPort int
-	// The endpoint where agents receive and respond to commands
-	MainEndpoint string
-	// The endpoint where agents login / register themselves
-	LoginEndpoint string
-	// Endpoint where payloads are staged
-	StageEndpoint string
-	// The folder where agent and c2 repositories are installed to.
-	SessionTimeout int `yaml:"session_timeout_minutes"`
-	InstallDir     string
-	// Credentials used by git for installing private packages
-	GitUsername string
-	GitPAT      string
-	// Ignore console warning logs
-	IgnoreConsoleWarnings bool
-	MysqlAddress          string
-	MysqlUsername         string
-	MysqlPassword         string
-}
-
-type MonarchClientConfig struct {
-	UUID      string `json:"uuid"`
-	Name      string `json:"name"`
-	RHost     string `json:"rhost"`
-	RPort     int    `json:"rport"`
-	CertPEM   []byte `json:"cert_pem"`
-	KeyPEM    []byte `json:"key_pem"`
-	CaCertPEM []byte `json:"ca_cert_pem"`
-	Secret    []byte `json:"secret"`
-	Challenge string `json:"challenge"`
-}
-
-type ProjectConfig struct {
-	Name          string
-	Version       string
-	Author        string
-	URL           string
-	SupportedOSes []string `yaml:"supported_os"`
-	// The command schema defines the possible commands that can be used with the agent.
-	// If the agent doesn't use commands to operate, then this configuration parameter is not necessary.
-	// On installation of the agent, the command schema is used by the builder when an operator requests to
-	// view commands.
-	CmdSchema []ProjectConfigCmd `yaml:"cmd_schema"`
-	Builder   Builder            `yaml:"builder"`
-}
-
-type ProjectConfigCmd struct {
-	Name    string
-	Usage   string
-	MinArgs int32 `yaml:"min_args"`
-	MaxArgs int32 `yaml:"max_args"` // Whether NArgs represents the minimum arg count or the exact
-	// Specifies whether this command requires admin privileges or not
-	Admin bool
-	// If opcode is specified, the provided integer opcode is used in place of the command name,
-	// promoting better OpSec
-	Opcode           int32
-	DescriptionShort string `yaml:"description_short"`
-	DescriptionLong  string `yaml:"description_long"`
-}
-
-type Builder struct {
-	// The directory where the build routine takes place
-	SourceDir string `yaml:"source_dir"`
-	// These are custom build arguments that can be used for building, in addition to default build arguments provided
-	// by the C2 itself.
-	BuildArgs []ProjectConfigBuildArg `yaml:"build_args"`
-}
-
-type ProjectConfigBuildArg struct {
-	Name        string
-	Description string
-	Default     string
-	Required    bool
-	Type        string
-	Choices     []string
-}
+// TODO:MALLEABLE C2 - ALLOW ARRAY OF ENDPOINTS FOR EACH HTTP(S) ENDPOINT (LOGIN, MAIN, ETC)
 
 func Initialize() {
 	home, _ := os.UserHomeDir()
@@ -121,6 +27,10 @@ func Initialize() {
 
 	if err := YamlConfig(MonarchConfigFile, &MainConfig); err != nil {
 		panic(fmt.Errorf("%v. was monarch installed with install-monarch.sh? ", err))
+	}
+	MainConfig.HttpConfig = norm(MainConfig.HttpConfig)
+	if err := JsonConfig(MainConfig.HttpConfig, &C2Config); err != nil {
+		panic(fmt.Errorf("couldn't read C2 configuration: %v", err))
 	}
 	MainConfig.CertFile = norm(MainConfig.CertFile)
 	MainConfig.KeyFile = norm(MainConfig.KeyFile)
@@ -137,8 +47,7 @@ func Home() string {
 }
 
 func norm(s string) string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".monarch", s)
+	return filepath.Join(Home(), s)
 }
 
 // ServerCertificates returns the PEM-encoded monarch server key pair
@@ -169,4 +78,22 @@ func JsonConfig(path string, config interface{}) error {
 		return err
 	}
 	return json.Unmarshal(data, config)
+}
+
+func newC2Config() HttpConfig {
+	loginCfg := &EndpointConfig{
+		Headers: make(map[string]string),
+	}
+	mainCfg := &EndpointConfig{
+		Headers: make(map[string]string),
+	}
+	stageCfg := &EndpointConfig{
+		Headers: make(map[string]string),
+	}
+	config := HttpConfig{
+		LoginEndpoint: loginCfg,
+		MainEndpoint:  mainCfg,
+		StageEndpoint: stageCfg,
+	}
+	return config
 }

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -1,0 +1,110 @@
+package config
+
+// MonarchConfig is only used by monarch itself, not clients
+type MonarchConfig struct {
+	// Set monarch logging level, which can be one of: debug (1), informational (2), warning (3), fatal (4)
+	LogLevel uint16
+	// Path to the certificate file used for TLS enabled connections.
+	CertFile string
+	// Path to the key file used for TLS enabled connections.
+	KeyFile string
+	// certificate authority x509 key pair
+	CaCert string
+	CaKey  string
+	// The main interface that Monarch will bind to for operations.
+	Interface string
+	// The port to use for the Monarch HTTP listener.
+	HttpPort int
+	// The port to use for the Monarch HTTPS listener.
+	HttpsPort int
+	// RPC port for multiplayer
+	MultiplayerPort int
+	// Port to use for the Monarch TCP listener.
+	TcpPort int
+	// A customisable configuration file for each HTTP endpoint
+	HttpConfig string
+	// The folder where agent and c2 repositories are installed to.
+	SessionTimeout int `yaml:"session_timeout_minutes"`
+	InstallDir     string
+	// Credentials used by git for installing private packages
+	GitUsername string
+	GitPAT      string
+	// Ignore console warning logs
+	IgnoreConsoleWarnings bool
+	MysqlAddress          string
+	MysqlUsername         string
+	MysqlPassword         string
+}
+
+type HttpConfig struct {
+	LoginEndpoint *EndpointConfig `json:"login_endpoint"`
+	MainEndpoint  *EndpointConfig `json:"main_endpoint"`
+	StageEndpoint *EndpointConfig `json:"stage_endpoint"`
+}
+
+type EndpointConfig struct {
+	Paths   []EndpointPath
+	Headers map[string]string
+}
+
+type EndpointPath struct {
+	Path    string
+	Methods []string
+}
+
+type MonarchClientConfig struct {
+	UUID      string `json:"uuid"`
+	Name      string `json:"name"`
+	RHost     string `json:"rhost"`
+	RPort     int    `json:"rport"`
+	CertPEM   []byte `json:"cert_pem"`
+	KeyPEM    []byte `json:"key_pem"`
+	CaCertPEM []byte `json:"ca_cert_pem"`
+	Secret    []byte `json:"secret"`
+	Challenge string `json:"challenge"`
+}
+
+type ProjectConfig struct {
+	Name          string
+	Version       string
+	Author        string
+	URL           string
+	SupportedOSes []string `yaml:"supported_os"`
+	// The command schema defines the possible commands that can be used with the agent.
+	// If the agent doesn't use commands to operate, then this configuration parameter is not necessary.
+	// On installation of the agent, the command schema is used by the builder when an operator requests to
+	// view commands.
+	CmdSchema []ProjectConfigCmd `yaml:"cmd_schema"`
+	Builder   Builder            `yaml:"builder"`
+}
+
+type ProjectConfigCmd struct {
+	Name    string
+	Usage   string
+	MinArgs int32 `yaml:"min_args"`
+	MaxArgs int32 `yaml:"max_args"` // Whether NArgs represents the minimum arg count or the exact
+	// Specifies whether this command requires admin privileges or not
+	Admin bool
+	// If opcode is specified, the provided integer opcode is used in place of the command name,
+	// promoting better OpSec
+	Opcode           int32
+	DescriptionShort string `yaml:"description_short"`
+	DescriptionLong  string `yaml:"description_long"`
+}
+
+type Builder struct {
+	// The directory where the build routine takes place
+	SourceDir string `yaml:"source_dir"`
+	// These are custom build arguments that can be used for building, in addition to default build arguments provided
+	// by the C2 itself.
+	BuildArgs []ProjectConfigBuildArg `yaml:"build_args"`
+}
+
+type ProjectConfigBuildArg struct {
+	Name        string
+	Description string
+	Default     string
+	Required    bool
+	Type        string
+	Choices     []string
+}

--- a/scripts/install-monarch.sh
+++ b/scripts/install-monarch.sh
@@ -54,6 +54,7 @@ docker run -dit --network ${MONARCH_NET} --ip 172.20.0.3 -e "MYSQL_ROOT_PASSWORD
   -e "MYSQL_DATABASE=monarch" --restart unless-stopped --name monarch-sql mysql:latest
 
 cp ../configs/monarch.yaml "${MONARCH_PATH}"
+cp ../configs/monarch_http.json "${MONARCH_PATH}"
 
 echo "generating self-signed CA certificate ca-cert.pem ca-key.pem"
 


### PR DESCRIPTION
# Features
- Configuration file `monarch_http.json` used for granular endpoint customisation
- Operators can modify the HTTP methods, paths and headers used for implant-server communication
- More intuitive `stage` command usage

# Changes
- Moved `unstage` command to `stage rm` subcommand
- top level `agents` command will only list all agents