### PR TITLE
Bug fix -  incomplete TCP socket read

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            sources:
+              - 'pkg/**'
+              - 'cmd/**'
+              - 'scripts/**'
       - uses: actions/setup-go@v4
+        if: steps.filter.outputs.sources == 'true'
         with:
           go-version: 1.21
       - name: Build all Monarch clients
+        if: steps.filter.outputs.sources == 'true'
         run: make linux macos windows
 
   build-test-monarch:
@@ -26,19 +36,32 @@ jobs:
           - "./scripts/docker-install-monarch.sh"
     steps:
       - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            sources:
+              - 'pkg/**'
+              - 'cmd/**'
+              - 'scripts/**'
+              - 'docker/monarch/**'
       - uses: actions/setup-go@v4
         with:
           go-version: 1.21
 
       - name: Install Monarch
+        if: steps.filter.outputs.sources == 'true'
         continue-on-error: false
         run: bash ${{ matrix.install_script }}
 
       - name: Setup Monarch Container
+        if: steps.filter.outputs.sources == 'true'
         continue-on-error: false
         run: docker build -t monarch -f docker/builder/Dockerfile .
 
       - name: Run Monarch tests
+        if: steps.filter.outputs.sources == 'true'
         run: go test ./...
       - name: Cleanup
+        if: steps.filter.outputs.sources == 'true'
         run: bash ./scripts/uninstall-monarch.sh

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -12,10 +12,22 @@ jobs:
       IMAGE_VERSION: latest # just for test
     steps:
       - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            sources:
+              - 'pkg/**'
+              - 'cmd/**'
+              - 'scripts/**'
+              - 'docker/builder/**'
+            python:
+              - 'python/**'
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
+        if: steps.filter.outputs.sources == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -23,6 +35,7 @@ jobs:
 
       - name: Push
         uses: docker/build-push-action@v3
+        if: steps.filter.outputs.sources == 'true'
         with:
           context: .
           push: false
@@ -31,9 +44,12 @@ jobs:
 
       - name: Install python package
         uses: actions/setup-python@v4
+        if: steps.filter.outputs.python == 'true'
         continue-on-error: false
 
       - name: upgrade pip packages
+        if: steps.filter.outputs.python == 'true'
         run: python3 -m pip install --user --upgrade setuptools wheel twine
       - name: setup distribution
+        if: steps.filter.outputs.python == 'true'
         run: python3 python/setup.py sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ See the [docs](https://monarch.gitbook.io/monarch) to learn more about Monarch a
 - Install builders from Git repositories or local folders
 - Docker used to set up builder containers
 - HTTP / HTTPS / raw TCP+TLS callback handlers
+- Malleable HTTP-based endpoints
 - Multiplayer and role-based access control
 - Easy 3rd party implant integration (documentation)
 - Client-server connections secured by mTLS

--- a/configs/monarch.yaml
+++ b/configs/monarch.yaml
@@ -12,6 +12,8 @@ httpport: 8000
 httpsport: 4433
 multiplayerport: 1337
 tcpport: 8888
+# the deadline for socket reads in milliseconds. This must be set as data sent through sockets is received in chunks
+tcpdeadline: 20
 
 # configuration for HTTP(S) c2 endpoints
 httpconfig: monarch_http.json

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -21,6 +21,9 @@ type MonarchConfig struct {
 	MultiplayerPort int
 	// Port to use for the Monarch TCP listener.
 	TcpPort int
+	// the deadline for socket reads in milliseconds.
+	// This must be set as data sent through sockets is received in chunks
+	TcpDeadline int
 	// A customisable configuration file for each HTTP endpoint
 	HttpConfig string
 	// The folder where agent and c2 repositories are installed to.


### PR DESCRIPTION
# Bug description
there is a limit to the data that can be read by calling `conn.Read` once. As such, commands with large outputs were only partially handled, and the leftover was stored  in conn, which would only be accessed on the next read. This causes panics due to unexpected data being received from the connection and parsed.

# Fix
`readPacket` function in `pkg/handler/tcp/tcp.go` reads data in chunks, and finishes once the deadline times out. Reading a 14MB file from a local interface with a deadline of 10ms works with no issues. Users have the option to modify the deadline from Monarch's configuration file.